### PR TITLE
Topic/remove cassavabase references

### DIFF
--- a/mason/about/sgn/index.mas
+++ b/mason/about/sgn/index.mas
@@ -5,9 +5,8 @@ The Erysimum Genome was sequenced by a consortium consisting of scientists at th
 
 <h3>Publication</h3>
 
-Citation goes here.
+Forthcoming - accepted in eLife.
 
 <h3>FAQ</h3>
 
 <div>For frequently asked questions, see the <a href="/help/faq">FAQ page</a>.</div>
-

--- a/mason/help/faq.mas
+++ b/mason/help/faq.mas
@@ -1,4 +1,4 @@
-<& "/page/page_title.mas", title => "Cassavabase: Frequently Asked Questions (FAQ)" &>
+<& "/page/page_title.mas", title => "Erysimum Database: Frequently Asked Questions (FAQ)" &>
 <table summary="" width="720" cellpadding="0" cellspacing="0"
   border="0">
     <tr>
@@ -8,23 +8,23 @@
           cellspacing="0" border="0">
             <tr>
               <td>
-                This page contains questions that Cassavabase users ask and
-                are useful to the larger cassava community. Please
+                This page contains questions that Erysimum Database users ask and
+                are useful to the larger community. Please
                 <a href="mailto:sgn-feedback\@sgn.cornell.edu">let
                 us know</a> if you have a question that you think
                 should be added.
 
 
-                <p><strong>Question:</strong> The CassavaBase pages look really
+                <p><strong>Question:</strong> The Erysimum Database pages look really
                 messed up on my browser.<br />
                 <strong>Answer:</strong> You are working with an old browser
                 that does not support style sheets, such as the
-                browsers of the Netscape 4.x series. CassavaBase pages
+                browsers of the Netscape 4.x series. Erysimum Database pages
                 require style sheets and javascript to be turned
                 on.</p>
 
                 <p><strong>Question:</strong> Can I submit my data to
-                CassavaBase?<br />
+                the Erysimum Database?<br />
                 <strong>Answer:</strong> Please send an email to <a href=
                 "mailto:sgn-feedback\@sgn.cornell.edu">sgn-feedback@sgn.cornell.edu</a>
                 with a description of the data you would like to
@@ -35,7 +35,7 @@
 
               </td>
             </tr>
-          </table>         
+          </table>
         </center>
       </td>
     </tr>

--- a/mason/help/index.mas
+++ b/mason/help/index.mas
@@ -5,11 +5,8 @@ The Erysimum Genome was sequenced by a consortium consisting of scientists at th
 
 <h3>Publication</h3>
 
-Citation goes here.
+Forthcoming - accepted in eLife.
 
 <h3>FAQ</h3>
 
 <div>For frequently asked questions, see the <a href="/help/faq">FAQ page</a>.</div>
-
-
-

--- a/mason/site/toolbar/logo_and_name.mas
+++ b/mason/site/toolbar/logo_and_name.mas
@@ -1,7 +1,7 @@
 
 <a class="navbar-brand" href="/" style="padding:10px 0px">
 
-<img id="sgnlogo" 
-src="/static/img/sgn_transparent_logo.png" width="60" alt="Template Home" title="Erysimum Home"></a>
+<img id="sgnlogo"
+src="/static/img/sgn_transparent_logo.png" width="50" alt="Template Home" title="Erysimum Home"></a>
 
 <a class="navbar-brand sgn_brand_name" href="/">Erysimum Database</a>


### PR DESCRIPTION
Fixed references to cassavabase, shrunk to logo so it fits in the toolbar, and made a few other aesthetic changes.